### PR TITLE
Change order of commands in less task, update other odds and ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make sure you have `yo` and `generator-ng-gulp` installed
 `npm install -g generator-ng-gulp yo`  
 `yo ng-gulp <app-name>`
 
-You can replace `<app-name>` with your apps name, or it will use the name of the folder it is in when being run.
+You can replace `<app-name>` with your app's name, or it will use the name of the folder it is in when being run.
 
 ### Options
 

--- a/app/index.js
+++ b/app/index.js
@@ -169,7 +169,7 @@ Generator.prototype.install = function install() {
 };
 
 Generator.prototype.end = function end() {
-	this.log('\n\nGreat! Now let me do so final touch ups...\n\n');
+	this.log('\n\nGreat! Now let me do some final touch ups...\n\n');
 	this.spawnCommand('gulp', ['bower']);
 
 	// Save app name, router info

--- a/app/templates/.jshintrc
+++ b/app/templates/.jshintrc
@@ -26,6 +26,7 @@
 		"jasmine": false,
 		"spyOn": false,
 		"xit": false,
-		"xdescribe": false
+		"xdescribe": false,
+		"$": false
 	}
 }

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -43,9 +43,9 @@ gulp.task('bower', function () {
 // Process css
 <% if (!useLess) { %>var cssGlob = ['app/app.css'];<% } else { %>var cssGlob = ['app/app.less', 'app/modules/**/*.less'];<% } %>
 gulp.task('css', function () {
-	gulp.src(cssGlob)<% if (useLess) { %>
+	gulp.src(cssGlob)
+		.pipe(concat('main.css'))<% if (useLess) { %>
 		.pipe(less())<% } %>
-		.pipe(concat('main.css'))
 		.pipe(autoprefixer({
 			remove: false
 		}))

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,14 +2,13 @@
 	"name": "mtc-app-gulp-test",
 	"version": "0.0.0",
 	"dependencies": {
-		"gulp": "~3.8.11",
-		"bower": "~1.3.12",
 		"karma": "~0.12.31"
 	},
 	"devDependencies": {
 		"browser-sync": "~2.6.0",
 		"del": "~1.1.1",
 		"express": "~4.12.3",
+		"gulp": "~3.8.11",
 		"gulp-autoprefixer": "~2.2.0",
 		"gulp-concat": "~2.5.2",
 		"gulp-headerfooter": "~1.0.3",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,13 +2,14 @@
 	"name": "mtc-app-gulp-test",
 	"version": "0.0.0",
 	"dependencies": {
+		"gulp": "~3.8.11",
+		"bower": "~1.3.12",
 		"karma": "~0.12.31"
 	},
 	"devDependencies": {
 		"browser-sync": "~2.6.0",
 		"del": "~1.1.1",
 		"express": "~4.12.3",
-		"gulp": "~3.8.11",
 		"gulp-autoprefixer": "~2.2.0",
 		"gulp-concat": "~2.5.2",
 		"gulp-headerfooter": "~1.0.3",


### PR DESCRIPTION
- Fix commands in css task so it concats, then runs less on the concatenated file.
- Add `$` to .jshintrc as it is incredibly widely used.
- Change dependencies in `package.json` so it automatically works in Bamboo.
- Fix random spelling/grammar errors.
